### PR TITLE
Add nullable type hint for paramProcessor

### DIFF
--- a/src/Internal/Runner.php
+++ b/src/Internal/Runner.php
@@ -50,7 +50,7 @@ abstract class Runner {
 	 * @param array $options
 	 * @param Processor|null $paramProcessor
 	 */
-	public function __construct( HookDefinition $definition, HookHandler $handler, array $options = [], Processor $paramProcessor = null ) {
+	public function __construct( HookDefinition $definition, HookHandler $handler, array $options = [], ?Processor $paramProcessor = null ) {
 		$this->definition = $definition;
 		$this->handler = $handler;
 


### PR DESCRIPTION
> Deprecated: ParserHooks\Internal\Runner::__construct(): Implicitly marking parameter $paramProcessor as nullable is deprecated, the explicit nullable type must be used instead in /srv/mediawiki/1.45/vendor/mediawiki/parser-hooks/src/Internal/Runner.php on line 53